### PR TITLE
Adds credentials to maven-publishing plugin repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ if necessary.
 
 > **Note:** Currently only Basic Authentication using username and password is supported at this time.
 
+### Maven-publishing suppport
+The plugin will also attempt to apply credentials to repositories configured using the maven-publishing plugin.
+
+    publishing {
+        repositories {
+            maven {
+                name = 'myRepo' // should match <id>myRepo</id> of appropriate <server> in settings.xml
+                url = 'https://intranet.foo.org/repo/repositories/releases'
+            }
+        }
+    }
+
 ## Profiles
 Profiles defined in a `settings.xml` will have their properties exported to the Gradle project when the profile is considered
 active. Active profiles are those listed in the `<activeProfiles>` section of the `settings.xml`, the `activeProfiles`

--- a/src/main/groovy/net/linguica/gradle/maven/settings/MavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/MavenSettingsPlugin.groovy
@@ -129,7 +129,12 @@ public class MavenSettingsPlugin implements Plugin<Project> {
     }
 
     private void applyRepoCredentials(Project project) {
-        project.repositories.all { repo ->
+        applyRepoCredentials(project, project.repositories)
+        applyRepoCredentials(project, project.extensions.findByName("publishing")?.repositories)
+    }
+
+    private void applyRepoCredentials(Project project, List<MavenArtifactRepository> repositories) {
+        repositories?.all { repo ->
             settings.servers.each { server ->
                 if (repo.name == server.id) {
                     addCredentials(server, repo)


### PR DESCRIPTION
The maven-publishing plugin adds a 'publishing' extension where
additional maven repositories are configured. This commit adds
credentials to the publishing repositories (if they exist) via the
repository name -> server id referencing mechanism.