### PR TITLE
Respect mirror exclude statements.

### DIFF
--- a/src/main/groovy/net/linguica/gradle/maven/settings/MavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/MavenSettingsPlugin.groovy
@@ -150,9 +150,10 @@ public class MavenSettingsPlugin implements Plugin<Project> {
 
     private void createMirrorRepository(Project project, Mirror mirror, Closure predicate) {
         boolean mirrorFound = false
+        List<String> excludedRepositoryNames = mirror.mirrorOf.split(',').findAll { it.startsWith("!") }.collect { it.substring(1) }
         project.repositories.all { repo ->
             if (repo instanceof MavenArtifactRepository && repo.name != ArtifactRepositoryContainer.DEFAULT_MAVEN_LOCAL_REPO_NAME
-                    && !repo.url.equals(URI.create(mirror.url)) && predicate(repo)) {
+                    && !repo.url.equals(URI.create(mirror.url)) && predicate(repo) && !excludedRepositoryNames.contains(repo.getName())) {
                 project.repositories.remove(repo)
                 mirrorFound = true
             }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/MavenSettingsPluginTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/MavenSettingsPluginTest.groovy
@@ -59,6 +59,37 @@ class MavenSettingsPluginTest extends AbstractMavenSettingsTest {
     }
 
     @Test
+    void respectsMirrorExcludes() {
+        withSettings {
+            mirrors.add new Mirror(id: 'myrepo', mirrorOf: '*,!some-repo', url: 'http://maven.foo.bar')
+        }
+
+        addPluginWithSettings()
+
+        project.with {
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven {
+                    name "some-repo"
+                    url "https://example.com"
+                }
+                maven {
+                    name "some-other-repo"
+                    url "https://example.com"
+                }
+            }
+        }
+
+        project.evaluate()
+
+        assertThat(project.repositories, hasSize(3))
+        assertThat(project.repositories, hasItem(hasProperty('name', equalTo('myrepo'))))
+        assertThat(project.repositories, hasItem(hasProperty('name', equalTo('MavenLocal'))))
+        assertThat(project.repositories, hasItem(hasProperty('name', equalTo('some-repo'))))
+    }
+
+    @Test
     void declareExternalMirrorWithFileRepo() {
         withSettings {
             mirrors.add new Mirror(id: 'myrepo', mirrorOf: 'external:*', url: 'http://maven.foo.bar')


### PR DESCRIPTION
A Maven mirror can be configured with excludes, that are in the form of !repo-name. In those cases it's wrong to replace the repository with the global mirror. Excluded repositories should be kept in the project repositories.

I've fixed it and also added a test case.